### PR TITLE
Fix html-webpack-plugin warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ HtmlWebpackWrapHtmlPlugin.prototype.apply = function(compiler) {
 				htmlPluginData.html += "\n" + options.after;
 			}
 
-			callback();
+			callback(null, htmlPluginData);
 		});
 	});
 };


### PR DESCRIPTION
Not returning the result in the callback is deprecated in html-webpack-plugin.